### PR TITLE
chore: bump to release 0.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "nuxt-user-example",
+  "name": "nuxt-auth-example",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
@@ -8,7 +8,7 @@
       "devDependencies": {
         "@fortawesome/fontawesome-free": "^6.2.0",
         "@nuxtjs/tailwindcss": "^6.1.0",
-        "@sidebase/nuxt-auth": "^0.3.0",
+        "@sidebase/nuxt-auth": "^0.3.1",
         "nuxt": "^3.0.0",
         "typescript": "^4.9.3"
       }
@@ -1570,9 +1570,9 @@
       "dev": true
     },
     "node_modules/@sidebase/nuxt-auth": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@sidebase/nuxt-auth/-/nuxt-auth-0.3.0.tgz",
-      "integrity": "sha512-I+8MwzccReS/4NeBZ0vnwDrCDavrs70sKBz0UbEuDfK5r/hlI1YgEAslgzuQ3Zq3uftKNvdge2UdvhJQKOvkfA==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@sidebase/nuxt-auth/-/nuxt-auth-0.3.1.tgz",
+      "integrity": "sha512-4pbWXYnrBvp1cIz8tqX1WVcMnWeDS9aivFD53RlxX1ItqDrPHlSEdFZkXlf2LfXtSK29Q68UuM6R+b8vsHs8cQ==",
       "dev": true,
       "dependencies": {
         "@nuxt/kit": "^3.0.0-rc.12",
@@ -11531,9 +11531,9 @@
       }
     },
     "@sidebase/nuxt-auth": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@sidebase/nuxt-auth/-/nuxt-auth-0.3.0.tgz",
-      "integrity": "sha512-I+8MwzccReS/4NeBZ0vnwDrCDavrs70sKBz0UbEuDfK5r/hlI1YgEAslgzuQ3Zq3uftKNvdge2UdvhJQKOvkfA==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@sidebase/nuxt-auth/-/nuxt-auth-0.3.1.tgz",
+      "integrity": "sha512-4pbWXYnrBvp1cIz8tqX1WVcMnWeDS9aivFD53RlxX1ItqDrPHlSEdFZkXlf2LfXtSK29Q68UuM6R+b8vsHs8cQ==",
       "dev": true,
       "requires": {
         "@nuxt/kit": "^3.0.0-rc.12",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "devDependencies": {
     "@fortawesome/fontawesome-free": "^6.2.0",
     "@nuxtjs/tailwindcss": "^6.1.0",
-    "@sidebase/nuxt-auth": "^0.3.0",
+    "@sidebase/nuxt-auth": "^0.3.1",
     "nuxt": "^3.0.0",
     "typescript": "^4.9.3"
   }


### PR DESCRIPTION
This PR bumps nuxt-auth to the just released `0.3.1`.
