### PR TITLE
Add kubernetes deployment

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -6,8 +6,8 @@ name: publish-sidebase-nuxt-auth-on-merge-main
 trigger:
   event:
     - push
-  branch:
-    - main
+  # branch:
+  #   - main
 
 steps:
 - name: publish-sidebase-nuxt-auth-on-merge-main
@@ -45,8 +45,8 @@ clone:
 trigger:
   event:
     - push
-  branch:
-     - main
+  # branch:
+  #    - main
 
 steps:
 - name: deploy_nuxt-auth-example.sidebase.io

--- a/.drone.yml
+++ b/.drone.yml
@@ -6,8 +6,8 @@ name: publish-sidebase-nuxt-auth-on-merge-main
 trigger:
   event:
     - push
-  # branch:
-  #   - main
+  branch:
+    - main
 
 steps:
 - name: publish-sidebase-nuxt-auth-on-merge-main
@@ -25,8 +25,6 @@ steps:
     cache_from:
       - ghcr.io/sidebase/nuxt-auth-example/nuxt-auth-example:main
     registry:  https://ghcr.io
-    # build_args:
-    #   - ORIGIN=https://nuxt-auth-example-k8s.sidebase.io
     username:
       from_secret: SIDECHART_USERNAME
     password:
@@ -47,11 +45,11 @@ clone:
 trigger:
   event:
     - push
-  # branch:
-  #    - main
+  branch:
+     - main
 
 steps:
-- name: deploy_nuxt-auth-example.sidebase.io
+- name: deploy
   image: deusavalon/aws-chamber-helmsman:0.1.0
   environment:
     AWS_ACCESS_KEY_ID:

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,73 @@
+---
+kind: pipeline
+type: docker
+name: publish-sidebase-nuxt-auth-on-merge-main
+
+trigger:
+  event:
+    - push
+  branch:
+    - main
+
+steps:
+- name: publish-sidebase-nuxt-auth-on-merge-main
+  image: plugins/docker
+  settings:
+    repo: ghcr.io/sidebase/nuxt-auth-example/sidebase-nuxt-auth
+    tags:
+        - "main"
+        - "${DRONE_COMMIT_SHA}"
+    custom_labels:
+        - key: org.opencontainers.image.source
+          value: https://github.com/sidebase/nuxt-auth-example
+    dockerfile: ./Dockerfile
+    context:  ./
+    cache_from:
+      - ghcr.io/sidebase/docs/sidebase-nuxt-auth-example:main
+    registry:  https://ghcr.io
+    username:
+      from_secret: SIDECHART_USERNAME
+    password:
+      from_secret: GITHUB_PACKAGES_TOKEN
+
+---
+
+kind: pipeline
+types: kubernetes
+name: deploy-sidebase-nuxt-auth-example
+
+environment:
+  GIT_LFS_SKIP_SMUDGE: 1
+
+clone:
+  depth: 1
+
+trigger:
+  event:
+    - push
+  branch:
+     - main
+
+steps:
+- name: deploy_nuxt-auth-example.sidebase.io
+  image: deusavalon/aws-chamber-helmsman:0.1.0
+  environment:
+    AWS_ACCESS_KEY_ID:
+      from_secret: "AWS_ACCESS_KEY_ID_FOR_KUBECONFIG"
+    AWS_SECRET_ACCESS_KEY:
+      from_secret: "AWS_SECRET_ACCESS_KEY_FOR_KUBECONFIG"
+    AWS_DEFAULT_REGION: "eu-central-1"
+    SIDECHART_TOKEN:
+      from_secret: "SIDECHART_TOKEN"
+    SIDECHART_USERNAME:
+      from_secret: "SIDECHART_USERNAME"
+    GITHUB_PACKAGES_TOKEN:
+      from_secret: "GITHUB_PACKAGES_TOKEN"
+  commands:
+    - cd kubernetes/helm
+    - chamber export sidebase/nuxt-auth/dev --format dotenv > .env
+    - aws eks update-kubeconfig --name eks-cluster-sidestream
+    - helmsman --apply --debug -f helmsman.yml
+
+depends_on:
+  - publish-sidebase-nuxt-auth-on-merge-main

--- a/.drone.yml
+++ b/.drone.yml
@@ -25,8 +25,8 @@ steps:
     cache_from:
       - ghcr.io/sidebase/nuxt-auth-example/nuxt-auth-example:main
     registry:  https://ghcr.io
-    build_args:
-      - ORIGIN=https://nuxt-auth-example-k8s.sidebase.io
+    # build_args:
+    #   - ORIGIN=https://nuxt-auth-example-k8s.sidebase.io
     username:
       from_secret: SIDECHART_USERNAME
     password:

--- a/.drone.yml
+++ b/.drone.yml
@@ -65,7 +65,7 @@ steps:
       from_secret: "GITHUB_PACKAGES_TOKEN"
   commands:
     - cd kubernetes/helm
-    - chamber export sidebase/nuxt-auth/dev --format dotenv > .env
+    - chamber export sidebase/nuxt-auth-example/dev --format dotenv > .env
     - aws eks update-kubeconfig --name eks-cluster-sidestream
     - helmsman --apply --debug -f helmsman.yml
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -13,7 +13,7 @@ steps:
 - name: publish-sidebase-nuxt-auth-on-merge-main
   image: plugins/docker
   settings:
-    repo: ghcr.io/sidebase/nuxt-auth-example/sidebase-nuxt-auth
+    repo: ghcr.io/sidebase/nuxt-auth-example/nuxt-auth-example
     tags:
         - "main"
         - "${DRONE_COMMIT_SHA}"
@@ -23,8 +23,10 @@ steps:
     dockerfile: ./Dockerfile
     context:  ./
     cache_from:
-      - ghcr.io/sidebase/docs/sidebase-nuxt-auth-example:main
+      - ghcr.io/sidebase/nuxt-auth-example/nuxt-auth-example:main
     registry:  https://ghcr.io
+    build_args:
+      - ORIGIN=https://nuxt-auth-example-k8s.sidebase.io
     username:
       from_secret: SIDECHART_USERNAME
     password:

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,9 +23,10 @@ FROM $NODE_VERSION-slim AS production
 
 COPY --from=production-base /app/.output /app/.output
 
-# Service hostname
+# Service hostname and port
 ENV NUXT_HOST=0.0.0.0
-
+ENV NUXT_PORT=80
+ENV PORT=80
 # Service version
 ARG NUXT_APP_VERSION
 ENV NUXT_APP_VERSION=${NUXT_APP_VERSION}

--- a/kubernetes/helm/helmsman.yml
+++ b/kubernetes/helm/helmsman.yml
@@ -38,3 +38,4 @@ apps:
       "secrets.data.github_client_id": "$GITHUB_CLIENT_ID"
       "secrets.data.github_client_secret": "$GITHUB_CLIENT_SECRET"
       "secrets.data.nuxt_secret": "$NUXT_SECRET"
+      "secrets.data.auth_origin": "$ORIGIN"

--- a/kubernetes/helm/helmsman.yml
+++ b/kubernetes/helm/helmsman.yml
@@ -1,0 +1,41 @@
+context: default
+
+metadata:
+  org: "github.com/sidebase/"
+  maintainer: "DevOps"
+  description: "Desired State File of the sidebase nuxt-auth-example deployment"
+
+settings:
+  kubeContext: "arn:aws:eks:eu-central-1:802385070966:cluster/eks-cluster-sidestream"
+  globalMaxHistory: 5
+
+namespaces:
+  sidebase-nuxt-auth:
+    protected: false
+
+helmRepos:
+  sidechart: "https://$SIDECHART_USERNAME:$SIDECHART_TOKEN@raw.githubusercontent.com/sidestream-tech/helm-charts/gh-pages/"
+
+apps:
+  sidebase-nuxt-auth:
+    namespace: "sidebase-nuxt-auth"
+    enabled: true
+    chart: "sidechart/sidechart"
+    version: "0.2.1"
+    valuesFile: values-sidebase-nuxt-auth.yml
+    test: false
+    protected: false
+    priority: -1
+    wait: true
+    timeout: 500
+    helmFlags: [
+      "--atomic",
+    ]
+    set:
+      "commitShortSHA": "$DRONE_COMMIT_SHA"
+      "image.tag": "$DRONE_COMMIT_SHA"
+      "imageCredentials.password": "$GITHUB_PACKAGES_TOKEN"
+      "secrets.data.github_client_id": "$GITHUB_CLIENT_ID"
+      "secrets.data.github_client_secret": "$GITHUB_CLIENT_SECRET"
+      "secrets.data.nuxt_secret": "$NUXT_SECRET"
+      "secrets.data.origin": "$ORIGIN"

--- a/kubernetes/helm/helmsman.yml
+++ b/kubernetes/helm/helmsman.yml
@@ -38,4 +38,3 @@ apps:
       "secrets.data.github_client_id": "$GITHUB_CLIENT_ID"
       "secrets.data.github_client_secret": "$GITHUB_CLIENT_SECRET"
       "secrets.data.nuxt_secret": "$NUXT_SECRET"
-      "secrets.data.origin": "$ORIGIN"

--- a/kubernetes/helm/values-sidebase-nuxt-auth.yml
+++ b/kubernetes/helm/values-sidebase-nuxt-auth.yml
@@ -20,7 +20,7 @@ service:
     external-dns.alpha.kubernetes.io/hostname: nuxt-auth-example-k8s.sidebase.io
   ports:
     http:
-      port: 3000
+      port: 80
   health: /api/healthz
   env:
     - name: "GREET"

--- a/kubernetes/helm/values-sidebase-nuxt-auth.yml
+++ b/kubernetes/helm/values-sidebase-nuxt-auth.yml
@@ -64,4 +64,4 @@ secrets:
     github_client_id: ""
     github_client_secret: ""
     nuxt_secret: ""
-    origin: ""
+    auth_origin: ""

--- a/kubernetes/helm/values-sidebase-nuxt-auth.yml
+++ b/kubernetes/helm/values-sidebase-nuxt-auth.yml
@@ -17,7 +17,7 @@ commitShortSHA: 123456
 service:
   type: LoadBalancer
   annotations:
-    external-dns.alpha.kubernetes.io/hostname: nuxt-auth-example-k8s.sidebase.io
+    external-dns.alpha.kubernetes.io/hostname: nuxt-auth-example.sidebase.io
   ports:
     http:
       port: 80

--- a/kubernetes/helm/values-sidebase-nuxt-auth.yml
+++ b/kubernetes/helm/values-sidebase-nuxt-auth.yml
@@ -20,7 +20,7 @@ service:
     external-dns.alpha.kubernetes.io/hostname: nuxt-auth-example-k8s.sidebase.io
   ports:
     http:
-      port: 80
+      port: 3000
   health: /api/healthz
   env:
     - name: "GREET"

--- a/kubernetes/helm/values-sidebase-nuxt-auth.yml
+++ b/kubernetes/helm/values-sidebase-nuxt-auth.yml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 image:
-  repository: ghcr.io/sidebase/nuxt-auth-example/sidebase-nuxt-auth
+  repository: ghcr.io/sidebase/nuxt-auth-example/nuxt-auth-example
   tag: main
   pullPolicy: IfNotPresent
 

--- a/kubernetes/helm/values-sidebase-nuxt-auth.yml
+++ b/kubernetes/helm/values-sidebase-nuxt-auth.yml
@@ -1,0 +1,67 @@
+replicaCount: 1
+
+image:
+  repository: ghcr.io/sidebase/nuxt-auth-example/sidebase-nuxt-auth
+  tag: main
+  pullPolicy: IfNotPresent
+
+imageCredentials:
+  password:
+
+volumes: []
+
+volumeMounts: []
+
+commitShortSHA: 123456
+
+service:
+  type: LoadBalancer
+  annotations:
+    external-dns.alpha.kubernetes.io/hostname: nuxt-auth-example-k8s.sidebase.io
+  ports:
+    http:
+      port: 80
+  health: /api/healthz
+  env:
+    - name: "GREET"
+      value: "scaffoldWashere"
+
+podAutoscaler:
+  minReplicas: 1
+  maxReplicas: 1
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 75
+
+oauth2:
+  enabled: false
+
+ingress:
+  enabled: false
+  class: nginx
+  certManager:
+    enabled: true
+    issuer: cloudflare-issuer
+  url: main.the-scaffold.k8s.sidestream.tech
+  timeoutEnabled: false
+  annotations: {}
+
+resources:
+  limits:
+    cpu: 250m
+    memory: 3Gi
+  requests:
+    cpu: 150m
+    memory: 2Gi
+
+secrets:
+  name: sidebase-nuxt-auth-secrets
+  data:
+    github_client_id: ""
+    github_client_secret: ""
+    nuxt_secret: ""
+    origin: ""

--- a/server/api/healthz.ts
+++ b/server/api/healthz.ts
@@ -1,0 +1,5 @@
+export default defineEventHandler((event) => {
+    return {
+        service: 'online'
+    }
+})


### PR DESCRIPTION
Closes N/A

- Adds CI/CD to automatically build and deploy to our k8s cluster
- Exposes to `nuxt-auth-example.sidebase.io` via a classic-loadbalancer and NOT via our new `*.sidebase.io` Ingress as we are still in the [free-tier](https://aws.amazon.com/elasticloadbalancing/pricing/) and the Ingress is being tested via a dummy deployment till Thursday to ensure no ACME/Certificate Issues
- Adds the `/api/healthz` healthcheck thanks to @zoey-kaiser 

Deployment workflow got fully tested and current `nuxt-auth-example.sidebase.io` is already running and exposed via our k8s-cluster.


Checklist:
- [x] issue number linked above after pound (`#`)
    - replace "Closes " with "Contributes to" or other if this PR does not close the issue
- [x] manually checked my feature / checking not applicable
- [x] wrote tests / testing not applicable
- [x] attached screenshots / screenshot not applicable
